### PR TITLE
add transpile / compile methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const createTSShim = (ts) => {
 
     return {
         version,
-        toJS: (code) => transpile(ts, code)
+        toJS: (code) => transpile(ts, code),
+        compile: (code) => compile(ts, code)
     }
 
 } 
@@ -16,8 +17,65 @@ function getVersion(ts) {
 }
 
 function transpile(ts, code) {
+    // Object.keys(ts).forEach(key => console.log(key))
+    // throw new Error('dfs')
     return ts.transpile(code)
 }
+
+function compile(ts, code) {
+    var diagnostics = []
+    var options = {
+        target: 1 /* ES5 */,
+        module: 0 /* None */,
+        // Filename can be non-ts file.
+        allowNonTsExtensions: true,
+        // We are not returning a sourceFile for lib file when asked by the program, 
+        // so pass --noLib to avoid reporting a file not found error.
+        noLib: true,
+        // We are not doing a full typecheck, we are not resolving the whole context,
+        // so pass --noResolve to avoid reporting missing file errors.
+        noResolve: true
+    }
+
+    // Parse
+    var inputFileName = "module.ts";
+    var sourceFile = ts.createSourceFile(inputFileName, code, options.target);
+    // if (moduleName) {
+    //     sourceFile.moduleName = moduleName;
+    // }
+    // Store syntactic diagnostics
+    if (diagnostics && sourceFile.parseDiagnostics) {
+        diagnostics.push.apply(diagnostics, sourceFile.parseDiagnostics);
+    }
+    var newLine = ts.getNewLineCharacter(options);
+    // Output
+    var outputText;
+    // Create a compilerHost object to allow the compiler to read and write files
+    var compilerHost = {
+        getSourceFile: function (fileName, target) { return fileName === inputFileName ? sourceFile : undefined; },
+        writeFile: function (name, text, writeByteOrderMark) {
+            ts.Debug.assert(outputText === undefined, "Unexpected multiple outputs for the file: " + name);
+            outputText = text;
+        },
+        getDefaultLibFileName: function () { return "lib.d.ts"; },
+        useCaseSensitiveFileNames: function () { return false; },
+        getCanonicalFileName: function (fileName) { return fileName; },
+        getCurrentDirectory: function () { return ""; },
+        getNewLine: function () { return newLine; }
+    };
+    var program = ts.createProgram([inputFileName], options, compilerHost);
+    if (diagnostics) {
+        diagnostics.push.apply(diagnostics, program.getCompilerOptionsDiagnostics());
+    }
+    // Emit
+    let emitResult = program.emit();
+
+    // console.log(emitResult)
+    // console.log(diagnostics)
+    // console.log(outputText)
+    return { outputText, diagnostics }
+}
+
 
 module.exports = {
     createTSShim

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 const createTSShim = (ts) => {
     const version = ts.version || getVersion(ts)
 
-
-
     return {
         version,
         toJS: (code) => transpile(ts, code),
@@ -17,15 +15,13 @@ function getVersion(ts) {
 }
 
 function transpile(ts, code) {
-    // Object.keys(ts).forEach(key => console.log(key))
-    // throw new Error('dfs')
     return ts.transpile(code)
 }
 
 function compile(ts, code) {
     var diagnostics = []
     var options = {
-        target: 1 /* ES5 */,
+        target: 'es6',
         module: 0 /* None */,
         // Filename can be non-ts file.
         allowNonTsExtensions: true,
@@ -65,7 +61,13 @@ function compile(ts, code) {
     };
     var program = ts.createProgram([inputFileName], options, compilerHost);
     if (diagnostics) {
-        diagnostics.push.apply(diagnostics, program.getCompilerOptionsDiagnostics());
+        if (program.getCompilerOptionsDiagnostics) {
+            diagnostics.push.apply(diagnostics, program.getCompilerOptionsDiagnostics());
+        } else if (program.getSyntacticDiagnostics && program.getOptionsDiagnostics) {
+            diagnostics = [];
+            ts.addRange(/*to*/ diagnostics, /*from*/ program.getSyntacticDiagnostics(sourceFile));
+            ts.addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
+        }
     }
     // Emit
     let emitResult = program.emit();

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const createTSShim = (ts) => {
 
     return {
         version,
-        toJS: () => ""
+        toJS: (code) => transpile(ts, code)
     }
 
 } 
@@ -13,6 +13,10 @@ const createTSShim = (ts) => {
 function getVersion(ts) {
     const keys = Object.keys(ts)
     
+}
+
+function transpile(ts, code) {
+    return ts.transpile(code)
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -51,9 +51,8 @@ ${outputText}
 diagnostics
 -----------
 
-${diagnostics}
+${diagnostics.map(diagnostic => `${diagnostic.messageText}, ${diagnostic.category}, ${diagnostic.code}, ${diagnostic.start}, ${diagnostic.length}`).join('\n')}
 `)
-expect(outputText).not.toBe(undefined)
-expect(diagnostics).not.toBe(undefined)
-
+    expect(outputText).not.toBe(undefined)
+    expect(diagnostics).not.toBe(undefined)
 })

--- a/test.js
+++ b/test.js
@@ -22,15 +22,21 @@ versions.forEach(v => {
     let ts = require(v) 
     if (Object.keys(ts).length === 0) ts = globalThis.TypeScript
 
-    console.log(Object.keys(ts).length)
-    // if(Object.keys(ts).length ===0) {
-        //     console.log(ts)
-        // }
-        expect(ts).toBeDefined()
-        
-        const brokenCode = `v ar abc = 123`
-    // const shimmed = createTSShim(ts)
+    expect(ts).toBeDefined()
     
-    // expect(shimmed.version).toBeDefined()
+    const brokenCode = `v ar abc = 123`
+    const shimmed = createTSShim(ts)
+    
+    expect(shimmed.version).toBeDefined()
+
+    const transpiled = shimmed.toJS(brokenCode)
+    console.log(`
+----------
+transpiled
+----------
+
+${transpiled}
+`)
+    expect(transpiled).not.toBe(undefined)
 
 })

--- a/test.js
+++ b/test.js
@@ -39,4 +39,21 @@ ${transpiled}
 `)
     expect(transpiled).not.toBe(undefined)
 
+    const { diagnostics, outputText } = shimmed.compile(brokenCode)
+    console.log(`
+--------
+compiled
+--------
+
+${outputText}
+
+-----------
+diagnostics
+-----------
+
+${diagnostics}
+`)
+expect(outputText).not.toBe(undefined)
+expect(diagnostics).not.toBe(undefined)
+
 })


### PR DESCRIPTION
I've been distracted by actually writing the [talk](https://blog.logrocket.com/logrocket-typescript-meetup-write-more-readable-code-with-typescript-4-4/) I'm giving this week; the idea of which prompted this repo in the first place.

Anyway, I just thought I'd have a little experiment. Here's a PR which adds transpile and extracting diagnostics support. It doesn't work with TypeScript < 1.5; probably for the reasons discussed in #1.

However, it does work otherwise!  If you run `node test` having excluded those versions you see output like that which you see at the end of the PR: (kind of fun to see how transpilation changes over the variety of TS versions :smile: )

It's taking the `brokenCode = 'v ar abc = 123'` and passing it through to `toJS` (which just does transpilation and was my v1 if you will), then calling a new `compile` method and printing out what is returned to the console; JS and diagnostics alike.

```
Running tests
Version: ts-15

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-16

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-17

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-18

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-20

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-21

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-22

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-23

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-24

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-25

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-26

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-27

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-28

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-29

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-30

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-31

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-32

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-33

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-34

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-35

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-36

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-37

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-38

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-39

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-40

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-41

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-42

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3

Version: ts-43

--------
compiled
--------

v;
ar;
abc = 123;


-----------
diagnostics
-----------

';' expected., 1, 1005, 2, 2
';' expected., 1, 1005, 5, 3
```